### PR TITLE
Add get request for HelpRequests by id

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -55,21 +55,21 @@ public class HelpRequestsController extends ApiController {
     }
 
     /**
-     * Get a single date by id
+     * Get a single help request by id
      * 
-     * @param id the id of the date
-     * @return a UCSBDate
+     * @param id the id of the help request
+     * @return a HelpRequest
      */
-    // @Operation(summary= "Get a single date")
-    // @PreAuthorize("hasRole('ROLE_USER')")
-    // @GetMapping("")
-    // public UCSBDate getById(
-    //         @Parameter(name="id") @RequestParam Long id) {
-    //     UCSBDate ucsbDate = ucsbDateRepository.findById(id)
-    //             .orElseThrow(() -> new EntityNotFoundException(UCSBDate.class, id));
-
-    //     return ucsbDate;
-    // }
+    @Operation(summary= "Get a single help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+            HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+                
+        return helpRequest;
+    }
 
     /**
      * Create a new help request

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
  * The HelpRequestRepository is a repository for HelpRequest entities
  */
 @Repository
-public interface HelpRequestRepository extends CrudRepository<HelpRequest, String> {
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
   
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -63,13 +63,13 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(200)); // logged
         }
 
-        // @Test
-        // public void logged_out_users_cannot_get_by_id() throws Exception {
-        //         mockMvc.perform(get("/api/ucsbdates?id=7"))
-        //                         .andExpect(status().is(403)); // logged out users can't get by id
-        // }
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
 
-        // Authorization tests for /api/ucsbdates/post
+        // Authorization tests for /api/helprequests/post
         // (Perhaps should also have these for put and delete)
 
         @Test
@@ -87,52 +87,55 @@ public class HelpRequestControllerTests extends ControllerTestCase {
 
         // // Tests with mocks for database actions
 
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
 
-        //         // arrange
-        //         LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
 
-        //         UCSBDate ucsbDate = UCSBDate.builder()
-        //                         .name("firstDayOfClasses")
-        //                         .quarterYYYYQ("20222")
-        //                         .localDateTime(ldt)
-        //                         .build();
+                HelpRequest helpRequest = HelpRequest.builder()
+                                .requesterEmail("a@gmail.com")
+                                .teamId("07")
+                                .requestTime(ldt)
+                                .tableOrBreakoutRoom("table 07")
+                                .explanation("need help")
+                                .solved(false)
+                                .build();
 
-        //         when(ucsbDateRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbDate));
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(get("/api/ucsbdates?id=7"))
-        //                         .andExpect(status().isOk()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().isOk()).andReturn();
 
-        //         // assert
+                // assert
 
-        //         verify(ucsbDateRepository, times(1)).findById(eq(7L));
-        //         String expectedJson = mapper.writeValueAsString(ucsbDate);
-        //         String responseString = response.getResponse().getContentAsString();
-        //         assertEquals(expectedJson, responseString);
-        // }
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(helpRequest);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
-        // @WithMockUser(roles = { "USER" })
-        // @Test
-        // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
 
-        //         // arrange
+                // arrange
 
-        //         when(ucsbDateRepository.findById(eq(7L))).thenReturn(Optional.empty());
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
-        //         // act
-        //         MvcResult response = mockMvc.perform(get("/api/ucsbdates?id=7"))
-        //                         .andExpect(status().isNotFound()).andReturn();
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
 
-        //         // assert
+                // assert
 
-        //         verify(ucsbDateRepository, times(1)).findById(eq(7L));
-        //         Map<String, Object> json = responseToJson(response);
-        //         assertEquals("EntityNotFoundException", json.get("type"));
-        //         assertEquals("UCSBDate with id 7 not found", json.get("message"));
-        // }
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
 
 
         @WithMockUser(roles = { "USER" })


### PR DESCRIPTION
Added a simple `GET` request for a help request by ID, with unit tests. No mutation or unit tests fail locally.

Closes #34 